### PR TITLE
Wait a frame on GameState init

### DIFF
--- a/src/gamestate_gamemode_init.asm
+++ b/src/gamestate_gamemode_init.asm
@@ -1,4 +1,6 @@
 GameMode_Init:
+      moveq #0x1, d0
+      jsr WaitFrames ; Wait a frame, to collect new joypad presses
       ; ************************************
       ; Load game map
       ; ************************************

--- a/src/gamestate_titlescreen_init.asm
+++ b/src/gamestate_titlescreen_init.asm
@@ -1,4 +1,6 @@
 TitleScreen_Init:
+      moveq #0x1, d0
+      jsr WaitFrames ; Wait a frame, to collect new joypad presses
       ; ************************************
       ; Load title screen map
       ; ************************************


### PR DESCRIPTION
This will be useful for the pause feature, so the joypadA_press from the
title screen won't get reused in GameMode, accidentally triggering the
pause menu.