### PR TITLE
Enabled asm68k optimisations

### DIFF
--- a/src/build.bat
+++ b/src/build.bat
@@ -9,7 +9,7 @@ rem /p pure binary
 rem /o enable optimisations
 rem ow+ optimise absolute long addressing
 @echo on
-asm68k.exe /k /p /o ow+ source.asm,../bin/rom.bin, , rom.lst
+asm68k.exe /k /p /o op+,os+,ow+,oz+,oaq+,osq+,omq+ source.asm,../bin/rom.bin, , rom.lst
 
 @echo off
 rem fix the rom header (checksum)


### PR DESCRIPTION
Taken from SATMAN.pdf:

OP - Optimise PC Relative
Switches to PC relative addressing from absolute long addressing if this
is permissible
in the current code context.

OS - Optimise Short Branch Optimisation
Backwards relative branches will use the short form if this is
permissible in the
current code context.

OW - Optimise Absolute Long Addressing
If the absolute long addressing mode is used but the address will only
occupy a word,
the Assembler will switch to the short form.
If a size is specified no optimisation will take place, thus:
move.w d0(fred) .1
will be left as absolute long.

OZ - Optimise Zero Displacements
If the address register is used with a zero displacement, the Assembler
will switch to
the address register indirect mode.

OAQ, OSQ and OMQ - Optimise to Quick Forms
When these options are enabled, provided that it is permissible in the
current